### PR TITLE
Fix/update to nonvulnerable guava

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
+
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: /
+  schedule:
+    interval: weekly
+  ignore:
+    # ignore any Maven artifacts - those are provided!
+    - dependency-name: "org.apache.maven:*"
+    - dependency-name: "org.apache.maven.plugin-tools:*"
+    # ignore Maven invoker - will be managed manually!
+    - dependency-name: "org.apache.maven.shared:maven-invoker"
+    # ignore slf4j - will be managed manually!
+    - dependency-name: "org.slf4j:*"
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.github.mavenplugins</groupId>
     <artifactId>org-parent</artifactId>
-    <version>4</version>
+    <version>8</version>
     <relativePath/>
   </parent>
 
@@ -18,19 +18,19 @@
 
   <developers>
     <developer>
-      <id>shillner</id>
-      <name>Stanley Hillner</name>
-      <organization>itemis AG</organization>
-      <organizationUrl>https://itemis.com/</organizationUrl>
-      <timezone>1</timezone>
-    </developer>
-    <developer>
       <id>mavenplugins</id>
       <!-- Let Maven Central Search show 'Public Project' as known contributors tag -->
       <name>Public Project</name>
       <url>https://github.com/mavenplugins/maven-cdi-plugin-hooks/graphs/contributors</url>
       <organization>mavenplugins</organization>
       <organizationUrl>https://github.com/mavenplugins/</organizationUrl>
+      <timezone>1</timezone>
+    </developer>
+    <developer>
+      <id>shillner</id>
+      <name>Stanley Hillner</name>
+      <organization>itemis AG</organization>
+      <organizationUrl>https://itemis.com/</organizationUrl>
       <timezone>1</timezone>
     </developer>
   </developers>
@@ -49,10 +49,9 @@
   <properties>
     <version.java>1.8</version.java>
     <!-- UNLEASH -->
-    <version.cdi-plugin-utils>4.0.0</version.cdi-plugin-utils>
+    <version.cdi-plugin-utils>4.0.1-SNAPSHOT</version.cdi-plugin-utils>
     <!-- 3rd PARTY -->
     <version.google-http-client>1.22.0</version.google-http-client>
-    <version.guava>19.0</version.guava>
     <!-- MAVEN -->
     <version.maven>3.3.9</version.maven>
     <version.maven-plugin-plugin>3.13.1</version.maven-plugin-plugin>
@@ -72,11 +71,6 @@
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
       <version>${version.google-http-client}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${version.guava}</version>
     </dependency>
 
     <!-- MAVEN DEPENDENCIES -->

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <!-- MAVEN -->
     <version.maven>3.3.9</version.maven>
     <version.maven-plugin-plugin>3.13.1</version.maven-plugin-plugin>
-    <version.maven-invoker>2.2</version.maven-invoker>
+    <version.maven-invoker>3.1.0</version.maven-invoker>
   </properties>
 
   <dependencies>

--- a/src/main/java/com/itemis/maven/plugins/cdi/hooks/mvn/MavenHook.java
+++ b/src/main/java/com/itemis/maven/plugins/cdi/hooks/mvn/MavenHook.java
@@ -74,7 +74,7 @@ public class MavenHook implements CDIMojoProcessingStep {
     request.setProfiles(profiles);
     request.setShellEnvironmentInherited(true);
     request.setOffline(this.settings.isOffline());
-    request.setInteractive(this.settings.isInteractiveMode());
+    request.setBatchMode(!this.settings.isInteractiveMode());
 
     this.log.info((isRollback ? "Rolling back " : "Executing ") + "hook " + context.getCompositeStepId()
         + " with the following setup:");


### PR DESCRIPTION
- pom.xml:
  - Update dependency io.github.mavenplugins:cdi-plugin-utils:4.0.0
    -> io.github.mavenplugins:cdi-plugin-utils:4.0.1
  - Remove explicit dependency to `com.google.guava:guava`
  - Update dependency `org.apache.maven.shared:maven-invoker:2.2` -> `org.apache.maven.shared:maven-invoker:3.1.0`

- MavenHook.java:
  - follow up API change of `org.apache.maven.shared.invoker.InvocationRequest`
 
- Add dependabot config
